### PR TITLE
Bugfix #10: Pairing mode doesn't work on QC35 II

### DIFF
--- a/src/.idea/codeStyles/Project.xml
+++ b/src/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <clangFormatSettings>
+      <option name="ENABLED" value="true" />
+    </clangFormatSettings>
+  </code_scheme>
+</component>

--- a/src/.idea/codeStyles/codeStyleConfig.xml
+++ b/src/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
   </state>
 </component>

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   build:
     image: bose-connect-app-linux:latest

--- a/src/library/based.h
+++ b/src/library/based.h
@@ -16,9 +16,9 @@
 #define DEVICE_ALIGNED_BYTES 64
 
 enum NoiseCancelling {
+  NC_OFF  = 0x00,
   NC_HIGH = 0x01,
   NC_LOW  = 0x03,
-  NC_OFF  = 0x00,
   NC_DNE  = 0xff,
   NC_UNKNOWN,
 };
@@ -51,15 +51,15 @@ enum PromptLanguage {
 };
 
 enum Pairing {
-  P_ON  = 0x01,
   P_OFF = 0x00,
+  P_ON  = 0x01,
   P_UNKNOWN,
 };
 
 enum DeviceStatus {
-  DS_THIS         = 0x03,
-  DS_CONNECTED    = 0x01,
   DS_DISCONNECTED = 0x00,
+  DS_CONNECTED    = 0x01,
+  DS_THIS         = 0x03,
 };
 
 enum DevicesConnected {


### PR DESCRIPTION
This `bugfix` resolves the issue https://github.com/airvzxf/bose-connect-app-linux/issues/10.