### PR TITLE
ci: upgrade actions/upload-artifact from v2 to v6

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,7 +50,7 @@ jobs:
           echo "BINARY_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
 
       - name: Archive binary's built
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.BINARY_NAME }}
           path: ${{github.workspace}}/src/build/${{ env.BINARY_NAME }}


### PR DESCRIPTION
## What

Bumps `actions/upload-artifact` from v2 to v6 in the `CMake` workflow. v2 was deprecated on 2024-02-13 and currently causes the build to be auto-failed before it can even start.

## Why

- v1 and v2 of the artifact actions are deprecated: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
- v2 is no longer installed on GitHub-hosted runners, so the workflow fails immediately.
- The rest of the repos in this account already run on the v6 major, so this change is the smallest possible diff to bring `CMake` in line.

## How

```diff
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.BINARY_NAME }}
           path: ${{github.workspace}}/src/build/${{ env.BINARY_NAME }}
```

The action's input API (`name`, `path`) is unchanged between v2 and v6, so the binary artifact continues to be uploaded with the same name and path. No other inputs are added.

## Verification

After merge, the next push to `main` (or a manual `workflow_dispatch`) should run `Archive binary's built` successfully and produce the `bose-connect-app-linux` artifact as before.

Closes #14