### PR TITLE
ci: migrate docker-compose v1 to docker compose v2

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,14 +22,14 @@ jobs:
 
       - name: Clean previous docker composes
         run: >
-          docker-compose \
+          docker compose \
             --project-directory ./src \
             --env-file ./src/.env-user \
             down
 
       - name: Start the docker compose
         run: >
-          docker-compose \
+          docker compose \
             --project-directory ./src \
             --env-file ./src/.env-user \
             up \


### PR DESCRIPTION
## What

Bumps the two `docker-compose` invocations in the `CMake` workflow to the v2 `docker compose` plugin. The v1 Python binary (`docker-compose`) is no longer installed on `ubuntu-latest` runners (Ubuntu 24.04), so the workflow has been failing at the very first docker step with `command not found`.

## Why

This is the follow-up to #15. After the upload-artifact deprecation was fixed, the build proceeded past the auto-fail and immediately died at:

``"
/home/runner/.../...sh: line 2: docker-compose: command not found
Process completed with exit code 127.
``"

The hosted runner image switched to Ubuntu 24.04, which ships only the Docker CLI v2 plugin (`docker compose`, with a space). The flags used by this workflow (`--project-directory`, `--env-file`, `up`, `down`, `--detach`, `--build`) are all supported by v2, so the behaviour is preserved.

The actual `./src/docker-compose.yml` file is intentionally left untouched — v2 reads v1-format compose files unchanged.

## How

```diff
-          docker-compose \
+          docker compose \
             --project-directory ./src \
             --env-file ./src/.env-user \
             down
```

Same edit in the `Start the docker compose` step. Two lines changed in total.

## Verification

After merge, the next `push` to `main` (or `workflow_dispatch`) should run all six steps of the `build` job end-to-end and produce the `bose-connect-app-linux` artifact as a downloadable archive on the run page.

Closes #16