### PR TITLE
ci(workflow): bump third-party actions to latest major

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,7 +50,7 @@ jobs:
           echo "BINARY_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
 
       - name: Archive binary's built
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BINARY_NAME }}
           path: ${{github.workspace}}/src/build/${{ env.BINARY_NAME }}

--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@1.1.0
+        uses: codacy/codacy-analysis-cli-action@v4
         with:
           verbose: true
           output: results.sarif
@@ -27,6 +27,6 @@ jobs:
           max-allowed-issues: 2147483647
 
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Install packages
         run: >
@@ -33,12 +33,12 @@ jobs:
             libbluetooth-dev
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v4
         # ✏️ If the Autobuild fails above, remove it and uncomment the
         #    following three lines and modify them (or add more) to build
         #    your code if your project uses a compiled language.
@@ -46,6 +46,6 @@ jobs:
         #  cmake ./src || true
 
       - name: Perform analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v4
         with:
           add-snippets: true


### PR DESCRIPTION
## Summary

Bump all third-party GitHub Actions called in this repo to their current floating major-version tags.

### Files & changes

**`.github/workflows/cmake.yml`**
- `actions/upload-artifact`: `v6` → `v7`

**`.github/workflows/codacy-analysis.yml`**
- `actions/checkout`: `v2` → `v7`
- `codacy/codacy-analysis-cli-action`: `1.1.0` → `v4`
- `github/codeql-action/upload-sarif`: `v1` → `v4`

**`.github/workflows/codeql-analysis.yml`**
- `actions/checkout`: `v2` → `v7`
- `github/codeql-action/init`: `v1` → `v4`
- `github/codeql-action/autobuild`: `v1` → `v4`
- `github/codeql-action/analyze`: `v1` → `v4`

All pins use floating major-version tags (`@v7`, `@v4`), not full SHAs or full versions.

### codacy 1.x → v4 input/output migration

`codacy/codacy-analysis-cli-action` v4 is a rewrite of the v1.x action. Several inputs/outputs were renamed. The current workflow passes:

```yaml
with:
  verbose: true
  output: results.sarif
  format: sarif
  gh-code-scanning-compat: true
  max-allowed-issues: 2147483647
```

Cross-checked against the v4 `action.yml` (https://github.com/codacy/codacy-analysis-cli-action/blob/v4/action.yml): all five of these input names (`verbose`, `output`, `format`, `gh-code-scanning-compat`, `max-allowed-issues`) still exist in v4 with the same semantics. **No input migration was required.** The workflow also does not reference any output of the codacy action, so no output migration was required either. The downstream `github/codeql-action/upload-sarif@v4` still accepts the `sarif_file` input we were already using.

### Verification

- Branched off the default branch (`main`).
- `actionlint` (latest) was run against the three modified workflow files. The only reported issues are pre-existing and out of scope for this bump:
  - a pre-existing `actions/checkout@v2` warning in `cmake.yml` (not in the bump list),
  - two pre-existing shellcheck warnings in `cmake.yml` (`SC2046`, `SC2086`).
  No new errors or warnings were introduced by this change.
- The commit is GPG-signed (verified with `git log -1 --pretty="%H %G? %s"` → `G …`).

### Why

Floating major-version tags pick up the latest stable patch/minor automatically, including security fixes, while still pinning to a known major. Several of the previous pins (`v1`, `v2`) target EOL/old major lines and are no longer supported on the current GitHub-hosted runners.