### PR TITLE
ci(workflow): bump checkout in cmake.yml to v7

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: Store user in environment file for Docker composer
         run: |


### PR DESCRIPTION
Follow-up to #18.

## What changed

- `actions/checkout@v2` → `@v7` in `.github/workflows/cmake.yml`

## Why

PR #18's regex-based scan missed the `- uses: actions/checkout@v2` line in `cmake.yml` because it uses a YAML list-item form that the first scan's pattern didn't catch. Bumping it to v7 brings the file in line with the rest of the repo (codacy-analysis.yml and codeql-analysis.yml are already on v7 after #18). The input surface used here is unchanged (no `with:` block), so the major bump is a drop-in.

## Verification

- [x] actionlint clean for the bumped step (the only actionlint warnings are pre-existing SC2046/SC2086 in unrelated `run:` blocks, out of scope here)
- [x] Commit is GPG-signed
- [x] Branched off the default branch (`main`)