### PR TITLE
ci(workflow): pin all external actions to SHA and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["actions/*", "github/*"]
+      third-party:
+        patterns: ["*"]
+        exclude-patterns: ["actions/*", "github/*"]
+    commit-message:
+      prefix: "ci"
+    labels: ["dependencies", "ci"]

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Store user in environment file for Docker composer
         run: |
@@ -50,7 +50,7 @@ jobs:
           echo "BINARY_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
 
       - name: Archive binary's built
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.BINARY_NAME }}
           path: ${{github.workspace}}/src/build/${{ env.BINARY_NAME }}

--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@v4
+        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4.4.7
         with:
           verbose: true
           output: results.sarif
@@ -27,6 +27,6 @@ jobs:
           max-allowed-issues: 2147483647
 
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install packages
         run: >
@@ -33,12 +33,12 @@ jobs:
             libbluetooth-dev
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         # ✏️ If the Autobuild fails above, remove it and uncomment the
         #    following three lines and modify them (or add more) to build
         #    your code if your project uses a compiled language.
@@ -46,6 +46,6 @@ jobs:
         #  cmake ./src || true
 
       - name: Perform analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           add-snippets: true


### PR DESCRIPTION
Pin all external GitHub Actions in `cmake.yml`, `codacy-analysis.yml`, and `codeql-analysis.yml` to immutable commit SHAs. Add Dependabot for weekly auto-updates.

Closes #20